### PR TITLE
Bundling Shaders in the distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Session.vim
 .netrwhist
 *~
 
+# node modules
+node_modules/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,4 +55,6 @@ module.exports = function(grunt) {
   grunt.registerTask('gen-shader-modules', 'replace');
   grunt.registerTask('build', 'browserify');
 
+  grunt.registerTask('default', ['replace','browserify']);
+
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,58 @@
+module.exports = function(grunt) {
+
+  grunt.loadNpmTasks('grunt-replace');
+  grunt.loadNpmTasks('grunt-browserify');
+
+  grunt.initConfig({
+
+    pkg: grunt.file.readJSON('package.json'),
+
+    replace: {
+      dist: {
+        options: {
+          preserveOrder: true,
+          usePrefix: false,
+          patterns: [
+            {
+              match: /^(.*)$/mg,
+              replacement: '$1\\n\\'
+            },
+            {
+              match: /^(.*)$/m,
+              replacement: 'module.exports = \"\\\n$1'
+            },
+            {
+              match: /^\\n\\$(\n)?/mg,
+              replacement: ''
+            },
+            {
+              match: /(.*)$/,
+              replacement: '$1\";'
+            }
+          ]
+        },
+        files: [{
+            expand: true,
+            flatten: true,
+            src: 'shaders/*',
+            dest: 'src/shaders/',
+            rename: function(dest, src) {
+              return dest + src.replace(/s$/,"s.js");
+            }
+        }]
+      }
+    },
+
+    browserify: {
+      dist: {
+        src: 'src/fisheyegl.js',
+        dest: 'dist/fisheyegl.js'
+      }
+    }
+
+  });
+
+  grunt.registerTask('gen-shader-modules', 'replace');
+  grunt.registerTask('build', 'browserify');
+
+}

--- a/dist/fisheyegl.js
+++ b/dist/fisheyegl.js
@@ -1,5 +1,5 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-FisheyeGl = function FisheyeGl(options){
+var FisheyeGl = function FisheyeGl(options){
 
   // Defaults:
   options = options || {};
@@ -300,6 +300,11 @@ FisheyeGl = function FisheyeGl(options){
   return distorter;
 
 }
+
+if (typeof(document) != 'undefined')
+  window.FisheyeGl = FisheyeGl;
+else
+  module.exports = FisheyeGl;
 
 },{"./shaders":2}],2:[function(require,module,exports){
 module.exports = {

--- a/dist/fisheyegl.js
+++ b/dist/fisheyegl.js
@@ -1,5 +1,5 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-module.exports = function FisheyeGl(options){
+FisheyeGl = function FisheyeGl(options){
 
   // Defaults:
   options = options || {};
@@ -44,8 +44,10 @@ module.exports = function FisheyeGl(options){
   var selector = options.selector || "#canvas";
   var gl = getGLContext(selector);
 
-  var vertexSrc = loadFile(options.vertexSrc || "../shaders/vertex.glvs");
-  var fragmentSrc = loadFile(options.fragmentSrc || "../shaders/fragment3.glfs");
+  var shaders = require('./shaders');
+
+  var vertexSrc = loadFile(options.vertexSrc || "vertex");
+  var fragmentSrc = loadFile(options.fragmentSrc || "fragment3");
 
   var program = compileShader(gl, vertexSrc, fragmentSrc)
   gl.useProgram(program);
@@ -133,6 +135,11 @@ module.exports = function FisheyeGl(options){
   }
 
   function loadFile(url, callback){
+
+    if(shaders.hasOwnProperty(url)) {
+      return shaders[url];
+    }
+
     var ajax = new XMLHttpRequest();
 
     if(callback) {
@@ -294,4 +301,185 @@ module.exports = function FisheyeGl(options){
 
 }
 
+},{"./shaders":2}],2:[function(require,module,exports){
+module.exports = {
+  fragment: require('./shaders/fragment.glfs'),
+  fragment2: require('./shaders/fragment2.glfs'),
+  fragment3: require('./shaders/fragment3.glfs'),
+  method1: require('./shaders/method1.glfs'),
+  method2: require('./shaders/method2.glfs'),
+  vertex: require('./shaders/vertex.glvs')
+};
+
+},{"./shaders/fragment.glfs":3,"./shaders/fragment2.glfs":4,"./shaders/fragment3.glfs":5,"./shaders/method1.glfs":6,"./shaders/method2.glfs":7,"./shaders/vertex.glvs":8}],3:[function(require,module,exports){
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec4 uLens;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord  * vec2(1.0, -1.0)/ 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	float scale = uLens.w;\n\
+	float F = uLens.z;\n\
+	\n\
+	float L = length(vec3(vPosition.xy/scale, F));\n\
+	vec2 vMapping = vPosition.xy * F / L;\n\
+	vMapping = vMapping * uLens.xy;\n\
+	vMapping = GLCoord2TextureCoord(vMapping/scale);\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	} \n\
+	gl_FragColor = texture;\n\
+}\n\
+";
+},{}],4:[function(require,module,exports){
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec4 uLens;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 TextureCoord2GLCoord(vec2 textureCoord) {\n\
+	return (textureCoord - vec2(0.5, 0.5)) * 2.0;\n\
+}\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord / 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	float correctionRadius = 0.5;\n\
+	float distance = sqrt(vPosition.x * vPosition.x + vPosition.y * vPosition.y) / correctionRadius;\n\
+	float theta = 1.0;\n\
+	if(distance != 0.0){\n\
+		theta = atan(distance);\n\
+	}\n\
+	vec2 vMapping = theta * vPosition.xy;\n\
+	vMapping = GLCoord2TextureCoord(vMapping);\n\
+		\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	} \n\
+	gl_FragColor = texture;\n\
+}\n\
+";
+},{}],5:[function(require,module,exports){
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec3 uLensS;\n\
+uniform vec2 uLensF;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord  * vec2(1.0, -1.0)/ 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	float scale = uLensS.z;\n\
+	vec3 vPos = vPosition;\n\
+	float Fx = uLensF.x;\n\
+	float Fy = uLensF.y;\n\
+	vec2 vMapping = vPos.xy;\n\
+	vMapping.x = vMapping.x + ((pow(vPos.y, 2.0)/scale)*vPos.x/scale)*-Fx;\n\
+	vMapping.y = vMapping.y + ((pow(vPos.x, 2.0)/scale)*vPos.y/scale)*-Fy;\n\
+	vMapping = vMapping * uLensS.xy;\n\
+	vMapping = GLCoord2TextureCoord(vMapping/scale);\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	}\n\
+	gl_FragColor = texture;\n\
+}\n\
+";
+},{}],6:[function(require,module,exports){
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec4 uLens;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 TextureCoord2GLCoord(vec2 textureCoord) {\n\
+	return (textureCoord - vec2(0.5, 0.5)) * 2.0;\n\
+}\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord / 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	vec2 vMapping = vec2(vTextureCoord.x, 1.0 - vTextureCoord.y);\n\
+	vMapping = TextureCoord2GLCoord(vMapping);\n\
+	//TODO insert Code\n\
+	float F = uLens.x/ uLens.w;\n\
+	float seta = length(vMapping) / F;\n\
+	vMapping = sin(seta) * F / length(vMapping) * vMapping;\n\
+	vMapping *= uLens.w * 1.414;\n\
+	vMapping = GLCoord2TextureCoord(vMapping);\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	} \n\
+	gl_FragColor = texture;\n\
+}\n\
+";
+},{}],7:[function(require,module,exports){
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec4 uLens;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 TextureCoord2GLCoord(vec2 textureCoord) {\n\
+	return (textureCoord - vec2(0.5, 0.5)) * 2.0;\n\
+}\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord / 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	vec2 vMapping = vec2(vTextureCoord.x, 1.0 - vTextureCoord.y);\n\
+	vMapping = TextureCoord2GLCoord(vMapping);\n\
+	//TOD insert Code\n\
+	float F = uLens.x/ uLens.w;\n\
+	float seta = length(vMapping) / F;\n\
+	vMapping = sin(seta) * F / length(vMapping) * vMapping;\n\
+	vMapping *= uLens.w * 1.414;\n\
+	vMapping = GLCoord2TextureCoord(vMapping);\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	} \n\
+	gl_FragColor = texture;\n\
+}\n\
+";
+},{}],8:[function(require,module,exports){
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+attribute vec3 aVertexPosition;\n\
+attribute vec2 aTextureCoord;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+void main(void){\n\
+	vPosition = aVertexPosition;\n\
+	vTextureCoord = aTextureCoord;\n\
+	gl_Position = vec4(vPosition,1.0);\n\
+}\n\
+";
 },{}]},{},[1]);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "url": "https://github.com/jywarren/fisheyegl/issues"
   },
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "grunt": "^1.0.1",
+    "grunt-browserify": "^5.0.0",
+    "grunt-replace": "^1.0.1"
+  },
   "homepage": "https://github.com/jywarren/fisheyegl"
 }

--- a/src/fisheyegl.js
+++ b/src/fisheyegl.js
@@ -1,4 +1,4 @@
-FisheyeGl = function FisheyeGl(options){
+var FisheyeGl = function FisheyeGl(options){
 
   // Defaults:
   options = options || {};
@@ -299,3 +299,8 @@ FisheyeGl = function FisheyeGl(options){
   return distorter;
 
 }
+
+if (typeof(document) != 'undefined')
+  window.FisheyeGl = FisheyeGl;
+else
+  module.exports = FisheyeGl;

--- a/src/fisheyegl.js
+++ b/src/fisheyegl.js
@@ -1,4 +1,3 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 module.exports = function FisheyeGl(options){
 
   // Defaults:
@@ -293,5 +292,3 @@ module.exports = function FisheyeGl(options){
   return distorter;
 
 }
-
-},{}]},{},[1]);

--- a/src/fisheyegl.js
+++ b/src/fisheyegl.js
@@ -43,8 +43,10 @@ module.exports = function FisheyeGl(options){
   var selector = options.selector || "#canvas";
   var gl = getGLContext(selector);
 
-  var vertexSrc = loadFile(options.vertexSrc || "../shaders/vertex.glvs");
-  var fragmentSrc = loadFile(options.fragmentSrc || "../shaders/fragment3.glfs");
+  var shaders = require('./shaders');
+
+  var vertexSrc = loadFile(options.vertexSrc || "vertex");
+  var fragmentSrc = loadFile(options.fragmentSrc || "fragment3");
 
   var program = compileShader(gl, vertexSrc, fragmentSrc)
   gl.useProgram(program);
@@ -132,6 +134,11 @@ module.exports = function FisheyeGl(options){
   }
 
   function loadFile(url, callback){
+
+    if(shaders.hasOwnProperty(url)) {
+      return shaders.url;
+    }
+
     var ajax = new XMLHttpRequest();
 
     if(callback) {

--- a/src/fisheyegl.js
+++ b/src/fisheyegl.js
@@ -1,4 +1,4 @@
-module.exports = function FisheyeGl(options){
+FisheyeGl = function FisheyeGl(options){
 
   // Defaults:
   options = options || {};
@@ -136,7 +136,7 @@ module.exports = function FisheyeGl(options){
   function loadFile(url, callback){
 
     if(shaders.hasOwnProperty(url)) {
-      return shaders.url;
+      return shaders[url];
     }
 
     var ajax = new XMLHttpRequest();

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -1,0 +1,8 @@
+module.exports = {
+  fragment: require('./shaders/fragment.glfs'),
+  fragment2: require('./shaders/fragment2.glfs'),
+  fragment3: require('./shaders/fragment3.glfs'),
+  method1: require('./shaders/method1.glfs'),
+  method2: require('./shaders/method2.glfs'),
+  vertex: require('./shaders/vertex.glvs')
+};

--- a/src/shaders/fragment.glfs.js
+++ b/src/shaders/fragment.glfs.js
@@ -1,0 +1,27 @@
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec4 uLens;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord  * vec2(1.0, -1.0)/ 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	float scale = uLens.w;\n\
+	float F = uLens.z;\n\
+	\n\
+	float L = length(vec3(vPosition.xy/scale, F));\n\
+	vec2 vMapping = vPosition.xy * F / L;\n\
+	vMapping = vMapping * uLens.xy;\n\
+	vMapping = GLCoord2TextureCoord(vMapping/scale);\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	} \n\
+	gl_FragColor = texture;\n\
+}\n\
+";

--- a/src/shaders/fragment2.glfs.js
+++ b/src/shaders/fragment2.glfs.js
@@ -1,0 +1,32 @@
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec4 uLens;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 TextureCoord2GLCoord(vec2 textureCoord) {\n\
+	return (textureCoord - vec2(0.5, 0.5)) * 2.0;\n\
+}\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord / 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	float correctionRadius = 0.5;\n\
+	float distance = sqrt(vPosition.x * vPosition.x + vPosition.y * vPosition.y) / correctionRadius;\n\
+	float theta = 1.0;\n\
+	if(distance != 0.0){\n\
+		theta = atan(distance);\n\
+	}\n\
+	vec2 vMapping = theta * vPosition.xy;\n\
+	vMapping = GLCoord2TextureCoord(vMapping);\n\
+		\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	} \n\
+	gl_FragColor = texture;\n\
+}\n\
+";

--- a/src/shaders/fragment3.glfs.js
+++ b/src/shaders/fragment3.glfs.js
@@ -1,0 +1,30 @@
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec3 uLensS;\n\
+uniform vec2 uLensF;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord  * vec2(1.0, -1.0)/ 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	float scale = uLensS.z;\n\
+	vec3 vPos = vPosition;\n\
+	float Fx = uLensF.x;\n\
+	float Fy = uLensF.y;\n\
+	vec2 vMapping = vPos.xy;\n\
+	vMapping.x = vMapping.x + ((pow(vPos.y, 2.0)/scale)*vPos.x/scale)*-Fx;\n\
+	vMapping.y = vMapping.y + ((pow(vPos.x, 2.0)/scale)*vPos.y/scale)*-Fy;\n\
+	vMapping = vMapping * uLensS.xy;\n\
+	vMapping = GLCoord2TextureCoord(vMapping/scale);\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	}\n\
+	gl_FragColor = texture;\n\
+}\n\
+";

--- a/src/shaders/method1.glfs.js
+++ b/src/shaders/method1.glfs.js
@@ -1,0 +1,31 @@
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec4 uLens;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 TextureCoord2GLCoord(vec2 textureCoord) {\n\
+	return (textureCoord - vec2(0.5, 0.5)) * 2.0;\n\
+}\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord / 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	vec2 vMapping = vec2(vTextureCoord.x, 1.0 - vTextureCoord.y);\n\
+	vMapping = TextureCoord2GLCoord(vMapping);\n\
+	//TODO insert Code\n\
+	float F = uLens.x/ uLens.w;\n\
+	float seta = length(vMapping) / F;\n\
+	vMapping = sin(seta) * F / length(vMapping) * vMapping;\n\
+	vMapping *= uLens.w * 1.414;\n\
+	vMapping = GLCoord2TextureCoord(vMapping);\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	} \n\
+	gl_FragColor = texture;\n\
+}\n\
+";

--- a/src/shaders/method2.glfs.js
+++ b/src/shaders/method2.glfs.js
@@ -1,0 +1,31 @@
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+uniform vec4 uLens;\n\
+uniform vec2 uFov;\n\
+uniform sampler2D uSampler;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+vec2 TextureCoord2GLCoord(vec2 textureCoord) {\n\
+	return (textureCoord - vec2(0.5, 0.5)) * 2.0;\n\
+}\n\
+vec2 GLCoord2TextureCoord(vec2 glCoord) {\n\
+	return glCoord / 2.0 + vec2(0.5, 0.5);\n\
+}\n\
+void main(void){\n\
+	vec2 vMapping = vec2(vTextureCoord.x, 1.0 - vTextureCoord.y);\n\
+	vMapping = TextureCoord2GLCoord(vMapping);\n\
+	//TOD insert Code\n\
+	float F = uLens.x/ uLens.w;\n\
+	float seta = length(vMapping) / F;\n\
+	vMapping = sin(seta) * F / length(vMapping) * vMapping;\n\
+	vMapping *= uLens.w * 1.414;\n\
+	vMapping = GLCoord2TextureCoord(vMapping);\n\
+	vec4 texture = texture2D(uSampler, vMapping);\n\
+	if(vMapping.x > 0.99 || vMapping.x < 0.01 || vMapping.y > 0.99 || vMapping.y < 0.01){\n\
+		texture = vec4(0.0, 0.0, 0.0, 1.0);\n\
+	} \n\
+	gl_FragColor = texture;\n\
+}\n\
+";

--- a/src/shaders/vertex.glvs.js
+++ b/src/shaders/vertex.glvs.js
@@ -1,0 +1,14 @@
+module.exports = "\
+#ifdef GL_ES\n\
+precision highp float;\n\
+#endif\n\
+attribute vec3 aVertexPosition;\n\
+attribute vec2 aTextureCoord;\n\
+varying vec3 vPosition;\n\
+varying vec2 vTextureCoord;\n\
+void main(void){\n\
+	vPosition = aVertexPosition;\n\
+	vTextureCoord = aTextureCoord;\n\
+	gl_Position = vec4(vPosition,1.0);\n\
+}\n\
+";


### PR DESCRIPTION
## What this PR Contains:

* Added Grunt
* Shaders are converted to modules using grunt
* Shaders are now included in the distribution with the help of CommonJS Require and Browserify


## How it works

The original shader files are in `./shaders/`. When `$ grunt` is run
* Grunt creates `./src/shaders/` and all the shader files are saved here as a require-able JS module.
* The shader files listing is maintained in `./src/shaders.js`
* All shader files are required in the main file `./src/fisheyegl.js`
* the bundled `./dist/fisheyegl.js` is created which contains the function `FisheyeGl` and all the shader files

The shader files can be passed like this:
```js
var distorter = FisheyeGl({
    vertexSrc: "vertex",
    fragmentSrc: "fragment3"
});
```

"vertex" and "fragment3" are the default vertex and fragment shaders, in case none is specified.

**vertexSrc** can either be a PATH to a custom vertex shader file or simply "vertex".

**fragmentSrc** can either be a PATH to a custom fragment shader file or one of these:
* "fragment"
* "fragment2"
* "fragment3"
* "method1"
* "method2"

## Benefits
* No unnecessary XMLHttp requests.
* Everything is bundled in a single file.
* Solves CORS Error problems for local implementations (i.e. without a server).

This resolves #12 