### PR TITLE
Fix typo that breaks drag and drop

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -120,7 +120,7 @@ jQuery(document).ready(function($) {
         var uniq = (new Date()).getTime();
         $('#previous').prepend('<a target="_blank" class="' + uniq + '" href="' + dataurl + '"></a>');
         $('.' + uniq).append(distorter.getImage());
-        distorter.setImage(event.target.result, function callback() {
+        distorter.setImage(e.target.result, function callback() {
           $('#grid').height($('#canvas').height());
           $('#grid').width($('#canvas').width());
         });


### PR DESCRIPTION
This closes #20 . I literally found this in seconds after opening the devtools to try to fix the issue, tested it and voilà!

Actually there was another error message in the console about EXIF not working :
```
Uncaught ReferenceError: EXIF is not defined
    onload https://jywarren.github.io/fisheyegl/example/main.js:136
    onDrop https://jywarren.github.io/fisheyegl/example/main.js:135
```